### PR TITLE
Populate reflection table

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Slack Channel Data</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.33.3/css/theme.bootstrap.min.css">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
         <h1>Slack Channel Data</h1>
         <button class="btn btn-primary" onclick="document.getElementById('fileInput').click()">Upload ZIP File</button>
         <input type="file" id="fileInput" accept=".zip" style="display:none;">
+        <div class="mb-3">
+            <label for="teamFilterInput" class="form-label">Filter by Team Name:</label>
+            <input type="text" class="form-control" id="teamFilterInput" placeholder="Enter team name...">
+        </div>
         <table id="dataTable" class="table table-striped">
             <thead>
                 <tr>
@@ -29,6 +33,8 @@
         </table>
         <div id="accordion" class="accordion"></div>
     </div>
+    
+    
     <script src="https://cdn.jsdelivr.net/npm/jszip/dist/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
     <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Slack Channel Data</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.33.3/css/theme.bootstrap.min.css">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/script.js
+++ b/script.js
@@ -160,9 +160,3 @@ function calculateGrade(channel) {
 }
 
 
-document.addEventListener('DOMContentLoaded', function () {
-    $("#dataTable").tablesorter({
-        theme: 'bootstrap',
-        widgets: ["zebra"]
-    });
-});

--- a/script.js
+++ b/script.js
@@ -1,53 +1,16 @@
-document.getElementById('fileInput').addEventListener('change', function (event) {
-    const file = event.target.files[0];
-    if (file) {
-        JSZip.loadAsync(file).then(function (zip) {
-            const channels = {};
-            const userIdToName = {};
-            const promises = [];
-
-            // Collect user info if users.json exists
-            if (zip.file("users.json")) {
-                const usersPromise = zip.file("users.json").async("string").then(function (content) {
-                    const users = JSON.parse(content);
-                    users.forEach(user => {
-                        if (user.id && user.name) {
-                            userIdToName[user.id] = user.name;
-                        }
-                    });
-                });
-                promises.push(usersPromise);
-            }
-
-            zip.forEach(function (relativePath, zipEntry) {
-                if (zipEntry.dir) return; // Skip directories
-                if (relativePath.endsWith('.json') && relativePath !== "users.json") {
-                    const promise = zipEntry.async("string").then(function (content) {
-                        const messages = JSON.parse(content);
-                        const channelName = relativePath.split('/')[0];
-                        if (!channels[channelName]) {
-                            channels[channelName] = {
-                                messageCount: 0,
-                                users: {},
-                                mergedCount: 0,
-                                closedCount: 0,
-                                reflectionCount: 0,
-                                logs: []
-                            };
-                        }
-                        channels[channelName].logs.push({ file: relativePath, content: messages });
-                        processMessages(messages, channels[channelName], userIdToName);
-                    });
-                    promises.push(promise);
-                }
-            });
-
-            Promise.all(promises).then(() => {
-                populateTableAndAccordion(channels);
-            });
-        });
-    }
-});
+function wrapHtml(content) {
+    // Convert the content to a JSON string and escape HTML special characters
+    const jsonString = JSON.stringify(content);
+    return jsonString.replace(/[&<>"']/g, function (match) {
+        return {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        }[match];
+    });
+}
 
 function processMessages(messages, channel, userIdToName) {
     messages.forEach(message => {
@@ -82,7 +45,7 @@ function populateTableAndAccordion(channels) {
         row.innerHTML = `
             <td>${channelName}</td>
             <td>${channel.messageCount}</td>
-            <td>${JSON.stringify(channel.users)}</td>
+            <td class="messages">${formatMessageCounts(channel.users)}</td>
             <td>${channel.mergedCount}</td>
             <td>${channel.closedCount}</td>
             <td>${channel.reflectionCount}</td>
@@ -113,6 +76,67 @@ function populateTableAndAccordion(channels) {
     });
 }
 
+document.getElementById('fileInput').addEventListener('change', function (event) {
+    const file = event.target.files[0];
+    if (file) {
+        JSZip.loadAsync(file).then(function (zip) {
+            const channels = {};
+            const userIdToName = {};
+            const promises = [];
+
+            // Collect user info if users.json exists
+            if (zip.file("users.json")) {
+                const usersPromise = zip.file("users.json").async("string").then(function (content) {
+                    const users = JSON.parse(content);
+                    users.forEach(user => {
+                        if (user.id && user.name) {
+                            userIdToName[user.id] = user.name;
+                        }
+                    });
+                });
+                promises.push(usersPromise);
+            }
+            zip.forEach(function (relativePath, zipEntry) {
+                if (zipEntry.dir) return; // Skip directories
+                if (relativePath.endsWith('.json') && relativePath !== "users.json") {
+                    const promise = zipEntry.async("string").then(function (content) {
+                        try {
+                            const messages = JSON.parse(content);
+                            if (Array.isArray(messages)) {
+                                const channelName = relativePath.split('/')[0];
+                                if (!channels[channelName]) {
+                                    channels[channelName] = {
+                                        messageCount: 0,
+                                        users: {},
+                                        mergedCount: 0,
+                                        closedCount: 0,
+                                        reflectionCount: 0,
+                                        logs: []
+                                    };
+                                }
+                                channels[channelName].logs.push({ file: relativePath, content: messages });
+                                processMessages(messages, channels[channelName], userIdToName);
+                            } else {
+                                console.error("Invalid JSON content: messages is not an array.");
+                            }
+                        } catch (error) {
+                            console.error("Error parsing JSON content:", error);
+                        }
+                    });
+                    promises.push(promise);
+                }
+            });
+            Promise.all(promises).then(() => {
+                populateTableAndAccordion(channels);
+            });
+        });
+    }
+});
+
+function formatMessageCounts(users) {
+    return Object.entries(users).map(([user, count]) => `${user}: ${count}`).join('<br>');
+}
+
 // Filter functions
 function messageFilter(message) {
     return message.text && message.text.length > 1;
@@ -134,3 +158,11 @@ function calculateGrade(channel) {
     const denominator = (channel.mergedCount * 2) + channel.closedCount;
     return denominator > 0 ? channel.reflectionCount / denominator : 0;
 }
+
+
+document.addEventListener('DOMContentLoaded', function () {
+    $("#dataTable").tablesorter({
+        theme: 'bootstrap',
+        widgets: ["zebra"]
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -10,15 +10,20 @@ td {
     text-align: left;
 }
 
+/* Limit the width of the Message Count column and allow content to wrap */
+td.messages {
+    width: 150px;
+    /* Adjust the width as needed */
+    max-height: 80px;
+    /* Adjust the height as needed */
+    overflow-y: auto;
+    word-break: break-word;
+}
+
 pre {
     white-space: pre-wrap;
-    /* Since CSS 2.1 */
     white-space: -moz-pre-wrap;
-    /* Mozilla, since 1999 */
     white-space: -pre-wrap;
-    /* Opera 4-6 */
     white-space: -o-pre-wrap;
-    /* Opera 7 */
     word-wrap: break-word;
-    /* Internet Explorer 5.5+ */
 }


### PR DESCRIPTION
In this PR, I made the following changes:

- Filter by typing team name
- Display each user on separate line in the 'message count' column
- Filter by regex patterns for closed/merged and count posts with replies

The criteria for counting reflection posts may be enhanced. E.g. message.length > 4 (LGTM)