### PR TITLE
Download CSV of Slack and Reflection Messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <h1>Slack Channel Data</h1>
         <button class="btn btn-primary" onclick="document.getElementById('fileInput').click()">Upload ZIP File</button>
         <input type="file" id="fileInput" accept=".zip" style="display:none;">
+        <button class="btn btn-secondary" id="downloadCSV">Download CSV</button>
         <div class="mb-3">
             <label for="teamFilterInput" class="form-label">Filter by Team Name:</label>
             <input type="text" class="form-control" id="teamFilterInput" placeholder="Enter team name...">

--- a/script.js
+++ b/script.js
@@ -395,20 +395,50 @@ function isReflection(message) {
     return patterns.some(pattern => pattern.test(message.text));
 }
 
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function isReflection(message) {
+    // Define the user ID of the slack-bot
+    const slackBotUserId = 'U073E1ZUGG6';
+
+    // Define patterns to match reflection messages
+    const patterns = [
+        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was merged :white_check_mark:.\n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i,
+        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was :x: closed but not merged! :x: \n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i
+        // Add any other user-defined patterns here
+    ];
+
+    // Check if message is from the slack-bot
+    if (message.user !== slackBotUserId) return false;
+
+    // Check if the message text matches any of the patterns
+    return patterns.some(pattern => pattern.test(message.text));
+}
+
 function generateCSV() {
     const rows = [];
     let totalMessages = 0;
     const reflectionThreadIds = new Set();
 
     // Add table headers
-    rows.push(['Channel', 'UTC Timestamp', 'User', 'Message ID', 'Thread ID', 'Text', 'isReflection']);
+    rows.push(['Channel', 'UTC Timestamp', 'Slack ID', 'User Name', 'Message ID', 'Thread ID', 'Text', 'isReflection']);
 
     Object.keys(channels).forEach(channelName => {
         const channel = channels[channelName];
+        console.log(`Processing channel: ${channelName}`); // Debugging statement
 
         channel.logs.forEach(log => {
             log.content.forEach(message => {
-                const userName = userIdToName[message.user] || message.user || 'unknown';
+                const userId = message.user || 'unknown';
+                const userName = userIdToName[userId] || 'unknown';
                 const messageId = message.client_msg_id || message.ts || 'unknown';
                 const threadId = message.thread_ts || 'none';
                 const utcTimestamp = message.ts ? new Date(parseFloat(message.ts) * 1000).toISOString() : 'unknown';
@@ -424,6 +454,7 @@ function generateCSV() {
                 rows.push([
                     escapeCSV(channelName),
                     escapeCSV(utcTimestamp),
+                    escapeCSV(userId),
                     escapeCSV(userName),
                     escapeCSV(messageId),
                     escapeCSV(threadId),
@@ -438,9 +469,9 @@ function generateCSV() {
 
     // Update the isReflection column for messages that are replies to reflection messages
     rows.forEach(row => {
-        const threadId = row[4]; // Thread ID is the 5th column
+        const threadId = row[5]; // Thread ID is the 6th column
         if (threadId !== 'none' && reflectionThreadIds.has(threadId)) {
-            row[6] = 1; // isReflection is the 7th column
+            row[7] = 1; // isReflection is the 8th column
         }
     });
 

--- a/script.js
+++ b/script.js
@@ -339,12 +339,41 @@ function escapeCSV(value) {
     return value;
 }
 
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function isReflection(message) {
+    // Define the user ID of the slack-bot
+    const slackBotUserId = 'U073E1ZUGG6';
+
+    // Define patterns to match reflection messages
+    const patterns = [
+        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was merged :white_check_mark:.\n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i,
+        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was :x: closed but not merged! :x: \n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i
+        // Add any other user-defined patterns here
+    ];
+
+    // Check if message is from the slack-bot
+    if (message.user !== slackBotUserId) return false;
+
+    // Check if the message text matches any of the patterns
+    return patterns.some(pattern => pattern.test(message.text));
+}
+
 function generateCSV() {
     const rows = [];
     let totalMessages = 0;
+    const reflectionThreadIds = new Set();
 
     // Add table headers
-    rows.push(['Channel', 'Timestamp', 'User', 'Message ID', 'Thread ID', 'Text']);
+    rows.push(['Channel', 'Timestamp', 'User', 'Message ID', 'Thread ID', 'Text', 'isReflection']);
 
     Object.keys(channels).forEach(channelName => {
         const channel = channels[channelName];
@@ -357,6 +386,12 @@ function generateCSV() {
                 const threadId = message.thread_ts || 'none';
                 const timestamp = message.ts ? new Date(parseFloat(message.ts) * 1000).toLocaleString() : 'unknown';
                 const text = message.text ? message.text.replace(/[\r\n]+/g, ' ') : 'No text available';
+                const isReflectionMessage = isReflection(message) ? 1 : 0;
+
+                // If the message is a reflection message, add its thread ID to the set
+                if (isReflectionMessage && threadId !== 'none') {
+                    reflectionThreadIds.add(threadId);
+                }
 
                 // Add message details to the CSV rows
                 rows.push([
@@ -365,12 +400,21 @@ function generateCSV() {
                     escapeCSV(userName),
                     escapeCSV(messageId),
                     escapeCSV(threadId),
-                    escapeCSV(text)
+                    escapeCSV(text),
+                    isReflectionMessage
                 ]);
 
                 totalMessages++;
             });
         });
+    });
+
+    // Update the isReflection column for messages that are replies to reflection messages
+    rows.forEach(row => {
+        const threadId = row[4]; // Thread ID is the 5th column
+        if (threadId !== 'none' && reflectionThreadIds.has(threadId)) {
+            row[6] = 1; // isReflection is the 7th column
+        }
     });
 
     console.log(`Total messages processed: ${totalMessages}`); // Debugging statement

--- a/script.js
+++ b/script.js
@@ -377,51 +377,6 @@ function escapeCSV(value) {
     return value;
 }
 
-function isReflection(message) {
-    // Define the user ID of the slack-bot
-    const slackBotUserId = 'U073E1ZUGG6';
-
-    // Define patterns to match reflection messages
-    const patterns = [
-        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was merged :white_check_mark:.\n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i,
-        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was :x: closed but not merged! :x: \n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i
-        // Add any other user-defined patterns here
-    ];
-
-    // Check if message is from the slack-bot
-    if (message.user !== slackBotUserId) return false;
-
-    // Check if the message text matches any of the patterns
-    return patterns.some(pattern => pattern.test(message.text));
-}
-
-function escapeCSV(value) {
-    if (typeof value === 'string') {
-        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
-        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
-            value = `"${value.replace(/"/g, '""')}"`;
-        }
-    }
-    return value;
-}
-
-function isReflection(message) {
-    // Define the user ID of the slack-bot
-    const slackBotUserId = 'U073E1ZUGG6';
-
-    // Define patterns to match reflection messages
-    const patterns = [
-        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was merged :white_check_mark:.\n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i,
-        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was :x: closed but not merged! :x: \n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i
-        // Add any other user-defined patterns here
-    ];
-
-    // Check if message is from the slack-bot
-    if (message.user !== slackBotUserId) return false;
-
-    // Check if the message text matches any of the patterns
-    return patterns.some(pattern => pattern.test(message.text));
-}
 
 function generateCSV() {
     const rows = [];
@@ -429,7 +384,7 @@ function generateCSV() {
     const reflectionThreadIds = new Set();
 
     // Add table headers
-    rows.push(['Channel', 'UTC Timestamp', 'Slack ID', 'User Name', 'Message ID', 'Thread ID', 'Text', 'isReflection']);
+    rows.push(['Channel', 'UTC Timestamp', 'Slack ID', 'User Name', 'Message ID', 'Thread Parent ID', 'Thread Role', 'Text', 'isReflection']);
 
     Object.keys(channels).forEach(channelName => {
         const channel = channels[channelName];
@@ -439,15 +394,39 @@ function generateCSV() {
             log.content.forEach(message => {
                 const userId = message.user || 'unknown';
                 const userName = userIdToName[userId] || 'unknown';
-                const messageId = message.client_msg_id || message.ts || 'unknown';
-                const threadId = message.thread_ts || 'none';
+                
+                // Use client_msg_id as the proper message ID, or generate a unique one
+                const messageId = message.client_msg_id || `generated-${userId}-${message.ts}`;
+                
+                // Thread handling - properly identify parent vs child messages
+                let threadParentId = 'none';
+                let threadRole = 'standalone';
+                
+                if (message.thread_ts) {
+                    threadParentId = message.thread_ts;
+                    if (message.ts === message.thread_ts) {
+                        threadRole = 'parent'; // This is a thread parent/starter
+                    } else {
+                        threadRole = 'reply';  // This is a reply in a thread
+                    }
+                }
+                
+                // Rest of the code remains the same
                 const utcTimestamp = message.ts ? new Date(parseFloat(message.ts) * 1000).toISOString() : 'unknown';
-                const text = message.text ? message.text.replace(/[\r\n]+/g, ' ') : 'No text available';
+                const text = message.text 
+                    ? message.text.replace(/[\r\n]+/g, ' ') 
+                    : message.files && message.files.length > 0
+                        ? `[File: ${message.files[0].name || message.files[0].title || 'attachment'} (Type: ${message.files[0].pretty_type || message.files[0].filetype || 'unknown'})${message.files[0].permalink ? ' - ' + message.files[0].permalink : ''}]`
+                        : message.file && (message.file.url_private || message.file.url_private_download)
+                            ? `[File: ${message.file.name || 'attachment'} (Type: ${message.file.pretty_type || message.file.filetype || 'unknown'})${message.file.permalink ? ' - ' + message.files[0].permalink : ''}]`
+                            : message.attachments && message.attachments.length > 0 && message.attachments[0].url
+                                ? `[URL: ${message.attachments[0].url}]`
+                                : 'No text available';
                 const isReflectionMessage = isReflection(message) ? 1 : 0;
 
-                // If the message is a reflection message, add its thread ID to the set
-                if (isReflectionMessage && threadId !== 'none') {
-                    reflectionThreadIds.add(threadId);
+                // If the message is a reflection message, add its thread parent ID to the set
+                if (isReflectionMessage && threadParentId !== 'none') {
+                    reflectionThreadIds.add(threadParentId);
                 }
 
                 // Add message details to the CSV rows
@@ -457,7 +436,8 @@ function generateCSV() {
                     escapeCSV(userId),
                     escapeCSV(userName),
                     escapeCSV(messageId),
-                    escapeCSV(threadId),
+                    escapeCSV(threadParentId),
+                    escapeCSV(threadRole),
                     escapeCSV(text),
                     isReflectionMessage
                 ]);
@@ -481,9 +461,12 @@ function generateCSV() {
     // Convert rows to CSV string
     const csvContent = rows.map(row => row.join(",")).join("\n");
 
-    // Create a Blob from the CSV string
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
+    // Add UTF-8 BOM at the beginning of the file
+    const BOM = new Uint8Array([0xEF, 0xBB, 0xBF]);
+    const csvWithBOM = new Blob([BOM, csvContent], { type: 'text/csv;charset=utf-8' });
+
+    // Create a Blob from the CSV string with BOM
+    const url = URL.createObjectURL(csvWithBOM);
 
     // Create a temporary link to download the CSV
     const link = document.createElement('a');

--- a/script.js
+++ b/script.js
@@ -367,24 +367,51 @@ function isReflection(message) {
     return patterns.some(pattern => pattern.test(message.text));
 }
 
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function isReflection(message) {
+    // Define the user ID of the slack-bot
+    const slackBotUserId = 'U073E1ZUGG6';
+
+    // Define patterns to match reflection messages
+    const patterns = [
+        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was merged :white_check_mark:.\n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i,
+        /:thinking_face: Hello from reflection bot! :thinking_face:\n PR <.*?> was :x: closed but not merged! :x: \n \*Each team member that was involved in this PR \(either coding or code review\)\*, please now write a brief reflection \*as a reply thread to this post\* on what you as an individual, or your team, learned from this PR, if anything\.\n Note that your team will be graded on two aspects:\n \n  \(1\) the percentage of prompts like this one to which your team responds,\n \n  \(2\) the quality of your responses\.\n\n\nSee <.*?> for details\./i
+        // Add any other user-defined patterns here
+    ];
+
+    // Check if message is from the slack-bot
+    if (message.user !== slackBotUserId) return false;
+
+    // Check if the message text matches any of the patterns
+    return patterns.some(pattern => pattern.test(message.text));
+}
+
 function generateCSV() {
     const rows = [];
     let totalMessages = 0;
     const reflectionThreadIds = new Set();
 
     // Add table headers
-    rows.push(['Channel', 'Timestamp', 'User', 'Message ID', 'Thread ID', 'Text', 'isReflection']);
+    rows.push(['Channel', 'UTC Timestamp', 'User', 'Message ID', 'Thread ID', 'Text', 'isReflection']);
 
     Object.keys(channels).forEach(channelName => {
         const channel = channels[channelName];
-        console.log(`Processing channel: ${channelName}`); // Debugging statement
 
         channel.logs.forEach(log => {
             log.content.forEach(message => {
                 const userName = userIdToName[message.user] || message.user || 'unknown';
                 const messageId = message.client_msg_id || message.ts || 'unknown';
                 const threadId = message.thread_ts || 'none';
-                const timestamp = message.ts ? new Date(parseFloat(message.ts) * 1000).toLocaleString() : 'unknown';
+                const utcTimestamp = message.ts ? new Date(parseFloat(message.ts) * 1000).toISOString() : 'unknown';
                 const text = message.text ? message.text.replace(/[\r\n]+/g, ' ') : 'No text available';
                 const isReflectionMessage = isReflection(message) ? 1 : 0;
 
@@ -396,7 +423,7 @@ function generateCSV() {
                 // Add message details to the CSV rows
                 rows.push([
                     escapeCSV(channelName),
-                    escapeCSV(timestamp),
+                    escapeCSV(utcTimestamp),
                     escapeCSV(userName),
                     escapeCSV(messageId),
                     escapeCSV(threadId),
@@ -419,7 +446,6 @@ function generateCSV() {
 
     console.log(`Total messages processed: ${totalMessages}`); // Debugging statement
     console.log(`Total rows in CSV: ${rows.length}`); // Debugging statement
-    console.log(`First few rows: ${JSON.stringify(rows.slice(0, 10))}`); // Debugging statement
 
     // Convert rows to CSV string
     const csvContent = rows.map(row => row.join(",")).join("\n");

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 const userIdToName = {};
-
+let channels = {};
 function wrapHtml(content) {
     const jsonString = JSON.stringify(content);
     return jsonString.replace(/[&<>"']/g, function (match) {
@@ -84,7 +84,6 @@ document.getElementById('fileInput').addEventListener('change', function (event)
     const file = event.target.files[0];
     if (file) {
         JSZip.loadAsync(file).then(function (zip) {
-            const channels = {};
             const promises = [];
 
             if (zip.file("users.json")) {
@@ -177,7 +176,7 @@ function calculateGrade(channel) {
     const closedNotMergedCount = channel.closedCount - channel.mergedCount;
     const denominator = (channel.mergedCount * 2) + closedNotMergedCount;
     const rawGrade = denominator > 0 ? channel.reflectionCount * 100 / denominator : 0;
-    return  (rawGrade <= 100.0) ? rawGrade : 100.0 ;
+    return (rawGrade <= 100.0) ? rawGrade : 100.0;
 }
 
 document.getElementById('teamFilterInput').addEventListener('keyup', function () {
@@ -300,3 +299,105 @@ function sortAccordionItems(sortedRows, columnIndex, direction) {
 // Call the function to make the table sortable
 makeTableSortable();
 
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function escapeCSV(value) {
+    if (typeof value === 'string') {
+        // Escape double quotes by doubling them and wrap the value in double quotes if it contains commas, newlines, or double quotes
+        if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value.replace(/"/g, '""')}"`;
+        }
+    }
+    return value;
+}
+
+function generateCSV() {
+    const rows = [];
+    let totalMessages = 0;
+
+    // Add table headers
+    rows.push(['Channel', 'Timestamp', 'User', 'Message ID', 'Thread ID', 'Text']);
+
+    Object.keys(channels).forEach(channelName => {
+        const channel = channels[channelName];
+        console.log(`Processing channel: ${channelName}`); // Debugging statement
+
+        channel.logs.forEach(log => {
+            log.content.forEach(message => {
+                const userName = userIdToName[message.user] || message.user || 'unknown';
+                const messageId = message.client_msg_id || message.ts || 'unknown';
+                const threadId = message.thread_ts || 'none';
+                const timestamp = message.ts ? new Date(parseFloat(message.ts) * 1000).toLocaleString() : 'unknown';
+                const text = message.text ? message.text.replace(/[\r\n]+/g, ' ') : 'No text available';
+
+                // Add message details to the CSV rows
+                rows.push([
+                    escapeCSV(channelName),
+                    escapeCSV(timestamp),
+                    escapeCSV(userName),
+                    escapeCSV(messageId),
+                    escapeCSV(threadId),
+                    escapeCSV(text)
+                ]);
+
+                totalMessages++;
+            });
+        });
+    });
+
+    console.log(`Total messages processed: ${totalMessages}`); // Debugging statement
+    console.log(`Total rows in CSV: ${rows.length}`); // Debugging statement
+    console.log(`First few rows: ${JSON.stringify(rows.slice(0, 10))}`); // Debugging statement
+
+    // Convert rows to CSV string
+    const csvContent = rows.map(row => row.join(",")).join("\n");
+
+    // Create a Blob from the CSV string
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    // Create a temporary link to download the CSV
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'slack_messages.csv');
+    document.body.appendChild(link);
+
+    // Trigger the download
+    link.click();
+
+    // Clean up
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+document.getElementById('downloadCSV').addEventListener('click', function () {
+    generateCSV();
+});


### PR DESCRIPTION
This PR adds a button to download a CSV of slack messages with the following columns:
Channel
UTC Timestamp	
Slack ID	
User Name	
Message ID	
Thread ID
Text	
isReflection

![image](https://github.com/user-attachments/assets/6ef0154d-26a1-41da-84a5-5b9858376cc5)

To see only reflection messages and responses, first filter the CSV by it "isReflection" column. Then sort first by Channel, then sort by Thread ID, and finally sort by  UTC Timestamp. This way the solution is generic, so that it could be used with other courses and channels.
